### PR TITLE
Add sleep to avoid pread errors while multiple threads being executed.

### DIFF
--- a/random.c
+++ b/random.c
@@ -2370,6 +2370,12 @@ static void *punch_hole(void *data)
 				strerror(errno));
 			return (void *)1;
 		}
+                /*
+                 * Add sleep to avoid pread error while multiple threads being executed in parallel 
+                 * OR can even ignore pread errors like other functions - truncate_down,collapse_range
+		 * let us go with sleep, tested with 20 threads loop works fine.
+                 */
+                sleep(1);
 		rc = safe_fallocate(file.fd_write,
 				    FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
 				    0, fsize);


### PR DESCRIPTION
     There seems to be an error - punch_hole pread: Input/output error, while executing the 2nd thread in the loop.
     So, this is the case of multiple threads execution issue.

     Either add sleep(1) or ignore pread error as it has been done in other cases.
     For example, see "truncate_down" or "collapse_range" functions they seems not checking
     for pread error at all, could be the same reason where pread is failing.

     So to avoid multiple threads in parallel adding sleep(1) between each thread execution so that we
     get pread call success for consecutive threads execution.

Signed-off-by: Kalpana Shetty <kalpana.shetty@amd.com>